### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ Token based authentication, ideal for CI servers.
 
 ## Usage
 
-Generate a token:
+Generate a token, with prompts for username and email address:
 
 ```sh
 npmo-auth-token generate
+```
+
+Generate a token, without prompts:
+
+```sh
+npmo-auth-token generate --user me --email me@me.co
 ```
 
 List your tokens:
@@ -19,10 +25,16 @@ List your tokens:
 npmo-auth-token list
 ```
 
-Delete a token:
+Delete a token, with prompt to select from a list:
 
 ```sh
 npmo-auth-token delete
+```
+
+Delete a token, without prompt:
+
+```sh
+npmo-auth-token delete --token deploy_0609bae9-cbcb-4bd6-a69c-3fae1a49fabd
 ```
 
 ## License

--- a/test/session.js
+++ b/test/session.js
@@ -1,10 +1,20 @@
 /* global describe it */
 
 var Session = require('../lib/session')
-var expect = require('chai').expect
+var chai = require('chai')
+var expect = chai.expect
+var tap = require('tap')
 
-require('chai').should()
-require('tap').mochaGlobals()
+chai.should()
+tap.mochaGlobals()
+
+tap.tearDown(function () {
+  var session = new Session()
+  session.client.flushdb(function (err) {
+    if (err) console.error('could not flush redis on test tearDown', err)
+    session.end()
+  })
+})
 
 describe('Session', function () {
   var prefixedKey = 'user-abc123'


### PR DESCRIPTION
Commit 0806968
- Allow `generate` command to accept CLI options and skip prompt (automation support)
- More details to README and CLI help text
- Make bin code a little more DRY with private functions

Commit 855a60f
- Add `tap.tearDown()` function to flush Redis db (this might be deleting too much)
