### PR TITLE
fix: fix annoying redis warning

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -67,7 +67,7 @@ Session.prototype.allSessions = function (cb) {
 }
 
 Session.prototype.end = function () {
-  this.client.end()
+  this.client.end(true)
 }
 
 module.exports = Session

--- a/test/session.js
+++ b/test/session.js
@@ -58,7 +58,7 @@ describe('Session', function () {
 
   it('returns a 500 error if something really strange happens', function (done) {
     var session = new Session()
-    session.client.end()
+    session.client.end(true)
     session.get('pork-chop-sandwiches', function (err, obj) {
       err.statusCode.should.equal(500)
       return done()


### PR DESCRIPTION
`end` should now have flush explicitly set to `true`.
